### PR TITLE
Get caminates without team 

### DIFF
--- a/src/app/dashboard/api/visor/caminantes/route.ts
+++ b/src/app/dashboard/api/visor/caminantes/route.ts
@@ -1,0 +1,98 @@
+import prisma from "@/configs/database";
+import { NextRequest, NextResponse } from "next/server";
+
+// Get caminantes without team if team could be null
+// export async function GET(request: NextRequest) {
+//   try {
+//     const searchParams = request.nextUrl.searchParams;
+//     const team = searchParams.get("team");
+
+//     const caminantes = await prisma.visor_Caminantes.findMany({
+//       where: {
+//         Team: team === "false" ? null : team === "true" ? { id: { not: undefined } } : undefined
+//       },
+//       select: {
+//         id: true,
+//         active: true,
+//         userId: true,
+//         User: {
+//           select: {
+//             User: {
+//               select: {
+//                 Person: {
+//                   select: {
+//                     name: true,
+//                     fatherLastName: true,
+//                     motherLastName: true
+//                   }
+//                 }
+//               }
+            
+//             }
+//           }
+//         }
+//       }
+//     });
+
+//     if (!caminantes.length) {
+//       return NextResponse.json({ code: "NOT_FOUND", message: "No caminantes found" });
+//     }
+
+//     return NextResponse.json({ code: "OK", message: "Caminantes retrieved successfully", data: caminantes });
+//   } catch (error) {
+//     console.log(error);
+//     return NextResponse.json({ code: "ERROR", message: "An error occurred" });
+//   }
+// }
+
+// Get caminantes without team (visor users with rol User)
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const team = searchParams.get("team");
+
+    const caminantes = await prisma.visor_User.findMany({
+      where: {
+        rol: "User",
+        ...(team === "false" && {
+          Caminantes: { none: {} },
+          Links: { none: {} }
+        }),
+        ...(team === "true" && {
+          OR: [
+            { Caminantes: { some: {} } },
+            { Links: { some: {} } }
+          ]
+        })
+      },
+      select: {
+        id: true,
+        active: true,
+        userId: true,
+        title: true,
+        rol: true,
+        User: {
+          select: {
+            Person: {
+              select: {
+                name: true,
+                fatherLastName: true,
+                motherLastName: true,
+              }
+            }
+          }
+        }
+      }
+    });
+
+    if (!caminantes.length) {
+      return NextResponse.json({ code: "NOT_FOUND", message: "No caminantes found" });
+    }
+
+    return NextResponse.json({ code: "OK", message: "Caminantes retrieved successfully", data: caminantes });
+  } catch (error) {
+    console.log(error);
+    return NextResponse.json({ code: "ERROR", message: "An error occurred" });
+  }
+}
+


### PR DESCRIPTION
- Se implementaron dos formas de hacerlo, una que se dejo comentada que es exclusivamente para usuarios que estén el el modelo Visor_Caminantes, para esto se tiene que tener las siguientes consideraciones:
    - Actualizar el modelo de la base de datos para que el team del caminante pueda ser null
    - Que solo se tomarían en cuenta los usuarios que estén en el modelo de Caminantes y no otros que también puedan serlo que se les asigno el rol de User en plataforma base

- La otra es directamente consultando en los usuarios del visor, donde aquellos que tengan el rol de "User" que es el rol que se les puede asignar a los caminantes, ya sean miembros de equipo o el enlace por lo tanto:
    - Se valida que el usuario no tenga equipo, es decir, no sea ni miembro de equipo ni enlace
    - Si es true trae a los que están ya sea como enlace o miembro
    - Si no viene el parámetro team se devuelven todos los usuarios que pueden ser o son caminantes