### PR TITLE
Delete coordinator and dependencies

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -212,11 +212,12 @@ model Visor_Structure {
 }
 
 model Visor_structureCoordinator {
-  id          String @id @default(auto()) @map("_id") @db.ObjectId
+  id          String  @id @default(auto()) @map("_id") @db.ObjectId
+  active      Boolean @default(true)
   structureId String
-  visorUserId String @db.ObjectId
-  technicalId String @db.ObjectId
-  attachId    String @db.ObjectId
+  visorUserId String  @db.ObjectId
+  technicalId String  @db.ObjectId
+  attachId    String  @db.ObjectId
 
   Technical Visor_User @relation("TechnicalRelation", fields: [technicalId], references: [id])
   Attach    Visor_User @relation("AttachRelation", fields: [attachId], references: [id])
@@ -290,6 +291,7 @@ model Visor_Caminantes {
 model Visor_Round {
   id            String   @id @default(auto()) @map("_id") @db.ObjectId
   createdAt     DateTime @default(now())
+  active        Boolean  @default(true)
   name          String
   startedAt     DateTime
   status        String
@@ -339,6 +341,7 @@ model Visor_Form {
 model Visor_Batch {
   id        String         @id @default(auto()) @map("_id") @db.ObjectId
   createdAt DateTime       @default(now())
+  active    Boolean        @default(true)
   name      String
   status    VisBatchStatus
   teamId    String         @db.ObjectId

--- a/src/app/dashboard/api/visor/structureCoordinators/[id]/route.ts
+++ b/src/app/dashboard/api/visor/structureCoordinators/[id]/route.ts
@@ -84,3 +84,264 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     return NextResponse.json({ code: "ERROR", message: "An error occurred" });
   }
 }
+
+// Change active status to false for all dependecies of a coordinator and change user titles to null
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const id = params.id;
+
+    // Verify if coordinator exists
+    const coordinatorExists = await prisma.visor_structureCoordinator.findFirst({
+      where: { id }
+    });
+
+    if (!coordinatorExists) {
+      return NextResponse.json({ code: "NOT_FOUND", message: "Coordinator not found" });
+    }
+
+    // if try to "deleted" again
+    if (!coordinatorExists.active){
+      return NextResponse.json({ code: "BAD_REQUEST", message: "Coordinator already deleted" });
+    }
+
+    // Get info of all relations of this structure
+    const subcoordinator = await prisma.visor_SubCoordinator.findFirst({
+      where: {
+        structureId: "territorial", active: true,
+      },
+      include: {
+        Technical: true,
+        User: true,
+        // Add clause where to filter only active registers
+        Auxiliaries: {
+          where: {
+            active: true
+          },
+          include: {
+            User: true,
+            Technical: true,
+            Teams: {
+              where: {
+                active: true
+              },
+              include: {
+                Link: true,
+                Caminantes: {
+                  where: {
+                    active: true
+                  },
+                  include: {
+                    User: true
+                  }
+                },
+                Batchs: {
+                  where: {
+                    active: true
+                  }
+                },
+                Rounds: {
+                  where: {
+                    active: true
+                  }
+                },
+              }
+            }
+          }
+        }
+      }
+    });
+
+    if (subcoordinator) {
+      // Get batchs info
+      const batchs = subcoordinator.Auxiliaries.flatMap(aux => aux.Teams.flatMap(team => team.Batchs));
+
+      // update batchs status to false
+      if (batchs) {
+        await prisma.visor_Batch.updateMany({
+          where: {
+            id: {
+              in: batchs.map(batch => batch.id)
+            }
+          },
+          data: {
+            active: false
+          }
+        });
+      }
+
+      // Get rounds info
+      const rounds = subcoordinator.Auxiliaries.flatMap(aux => aux.Teams.flatMap(team => team.Rounds));
+
+      // update rounds status to false
+      if (rounds) {
+        await prisma.visor_Round.updateMany({
+          where: {
+            id: {
+              in: rounds.map(round => round.id)
+            }
+          },
+          data: {
+            active: false
+          }
+        });
+      }
+
+      // Get caminantes info
+      const caminantes = subcoordinator.Auxiliaries.flatMap(aux => aux.Teams.flatMap(team => team.Caminantes));
+      const users = caminantes.map(caminante => caminante.User);
+
+      if (caminantes) {
+        // update title to users
+        if (users) {
+          await prisma.visor_User.updateMany({
+            where: {
+              id: {
+                in: users.map(user => user.id)
+              }
+            },
+            data: {
+              title: null
+            }
+          });
+        }
+
+        // update caminantes status to false
+        await prisma.visor_Caminantes.updateMany({
+          where: {
+            id: {
+              in: caminantes.map(caminante => caminante.id)
+            }
+          },
+          data: {
+            active: false,
+          }
+        });
+      }
+
+      // Get team info
+      const teams = subcoordinator.Auxiliaries.flatMap(aux => aux.Teams);
+      const teamLinks = teams.flatMap(team => team.Link);
+
+      if (teams) {
+        // update title to links
+        if (teamLinks) {
+          await prisma.visor_User.updateMany({
+            where: {
+              id: {
+                in: teamLinks.map(link => link.id)
+              }
+            },
+            data: {
+              title: null
+            }
+          });
+        }
+
+        // update team status to false
+        await prisma.visor_Team.updateMany({
+          where: {
+            id: {
+              in: teams.map(team => team.id)
+            }
+          },
+          data: {
+            active: false
+          }
+        });
+      }
+
+      // Get auxiliaries info
+      const auxiliaries = subcoordinator.Auxiliaries;
+      const auxUsers = auxiliaries.map(aux => aux.User);
+      const auxTechnicals = auxiliaries.map(aux => aux.Technical);
+
+      if (auxiliaries) {
+        // update title to users auxiliaries
+        if (auxUsers) {
+          await prisma.visor_User.updateMany({
+            where: {
+              id: {
+                in: auxUsers.map(user => user.id)
+              }
+            },
+            data: {
+              title: null
+            }
+          });
+        }
+
+        // update title to users technicals
+        if (auxTechnicals) {
+          await prisma.visor_User.updateMany({
+            where: {
+              id: {
+                in: auxTechnicals.map(technical => technical.id)
+              }
+            },
+            data: {
+              title: null
+            }
+          });
+        }
+
+        // update auxiliaries status to false
+        await prisma.visor_Auxiliaries.updateMany({
+          where: {
+            id: {
+              in: auxiliaries.map(aux => aux.id)
+            }
+          },
+          data: {
+            active: false
+          }
+        });
+      }
+
+      // update title to user of subcoordination to null and status to false
+      await prisma.visor_SubCoordinator.update({
+        where: { id: subcoordinator.id },
+        data: {
+          User: {
+            update: {
+              title: null
+            }
+          },
+          Technical: {
+            update: {
+              title: null
+            }
+          },
+          active: false
+        }
+      });
+    }
+
+    // update coordinator status and user titles
+    const updateResult = await prisma.visor_structureCoordinator.update({
+      where: { id },
+      data: {
+        active: false,
+        Attach: {
+          update: {
+            title: null
+          }
+        },
+        Technical: {
+          update: {
+            title: null
+          }
+        },
+        VisorUser: {
+          update: {
+            title: null
+          }
+        }
+      }
+    });
+
+    return NextResponse.json({ code: "OK", message: "Coordinator deleted successfully", data: updateResult });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ code: "ERROR", message: "An error occurred" });
+  }
+}

--- a/src/app/dashboard/api/visor/structureCoordinators/[id]/route.ts
+++ b/src/app/dashboard/api/visor/structureCoordinators/[id]/route.ts
@@ -23,11 +23,36 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     }
 
     // Verify if coordinator exists
-    const coordinatorExists = await prisma.visor_structureCoordinator.findFirst({ where: { id } });
+    const coordinatorExists = await prisma.visor_structureCoordinator.findFirst({
+      where: { id },
+      include: {
+        Technical: true,
+        Attach: true
+      }
+    });
 
     if (!coordinatorExists) {
       return NextResponse.json({ code: "NOT_FOUND", message: "Coordinator not found" });
     }
+
+    // Update title of free users (when a user is change in structure)
+    await prisma.visor_structureCoordinator.update({
+      where: { id },
+      data: {
+        Technical: {
+          update: {
+            title: technicalId === coordinatorExists.technicalId ?
+              coordinatorExists.Technical.title : null
+          }
+        },
+        Attach: {
+          update: {
+            title: attachId === coordinatorExists.attachId ?
+              coordinatorExists.Attach.title : null
+          }
+        }
+      }
+    });
 
     // Update coordination info of structure and titles of the users
     const updateResult = await prisma.visor_structureCoordinator.update({


### PR DESCRIPTION
- Se cambia el estatus de active para la propia entidad el coordinador y todas las demás que tengan que ver con este:
    - Subcoordinador
    - Auxiliares
    - Equipos
    - Caminantes
    - Rondas
    - Tandas
- De igual manera se actualizan todos los títulos a null de todos los usuarios involucrados en cada una de las entidades mencionadas
- Se prevee que actualice todo lo que este activo, lo que no lo este quiere decir que ya se había "eliminado" antes
- Además verifica que haya registros en cada entidad para poder borrar actualizar antes de hacer el proceso
- Verifica otro intento de eliminar y manda code BAD_REQUEST, esto como respuesta a que ya ha sido "eliminado" 
- Se agregó una validación en la ruta PATCH de el coordinador, para actualizar los títulos de los usuarios que se cambien
- Se agregaron capos de active a algunos de los modelos donde era necesario