### PR TITLE
Modal: Create, update and delete coordinator

### DIFF
--- a/src/app/dashboard/api/visor/structureCoordinators/[id]/route.ts
+++ b/src/app/dashboard/api/visor/structureCoordinators/[id]/route.ts
@@ -2,6 +2,31 @@ import prisma from "@/configs/database";
 import { NextRequest, NextResponse } from "next/server";
 import { hasIncompleteFields } from "@/utils";
 
+// get coordinator
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const id = params.id;
+
+    const coordinator = await prisma.visor_structureCoordinator.findFirst({
+      where: { id, active: true },
+      include: {
+        Technical: true,
+        Attach: true,
+        VisorUser: true
+      }
+    });
+
+    if (!coordinator) {
+      return NextResponse.json({ code: "NOT_FOUND", message: "Coordinator not found" });
+    }
+
+    return NextResponse.json({ code: "OK", message: "Coordinator retrieved successfully", data: coordinator });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ code: "ERROR", message: "An error occurred" });
+  }
+}
+
 export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   interface reqBody {
     structureId: string;


### PR DESCRIPTION
**Se implementaron las siguientes cosas en el modal de coordinador de estructura:**
- Creación de un nuevo coordinador
- Modificación de un coordinador existente
- Eliminación de un coordinador existente
- Se asegura que se tenga la información de los selects siempre actualizada a la hora de abrir el modal

Se agrego una ruta GET, para obtener la información de una coordinación de estructura por id

_Solo me quedo una duda, según entiendo solo va a haber un coordinador por estructura, por lo que para crearlo habría que modificar la ruta y asegurar que solo haya uno por estructura, lo mismo si se intenta modificar, si es asi me avisas para hacer esas modificaciones a las rutas y validaciones en el modal_