### PR TITLE
Implement the team creation modal and fix the teams page so that everything is used by the id

### DIFF
--- a/src/app/dashboard/api/visor/caminantes/route.ts
+++ b/src/app/dashboard/api/visor/caminantes/route.ts
@@ -55,8 +55,9 @@ export async function GET(request: NextRequest) {
       where: {
         rol: "User",
         ...(team === "false" && {
-          Caminantes: { none: {} },
-          Links: { none: {} }
+          // Caminantes: { none: {} },
+          // Links: { none: {} }
+          title: null
         }),
         ...(team === "true" && {
           OR: [

--- a/src/app/dashboard/visor/teams/page.tsx
+++ b/src/app/dashboard/visor/teams/page.tsx
@@ -65,11 +65,6 @@ export default function Teams() {
     handleGetTeamsAndSetThem();
   }, []);
 
-  // useEffect para imprimir los equipos filtrados y totales en la consola cuando cambian
-  useEffect(() => {
-    console.log({ filteredTeams, teams });
-  }, [filteredTeams, teams]);
-
   // useEffect para filtrar los equipos según el término de búsqueda
   useEffect(() => {
     if (!teams) return;
@@ -81,7 +76,7 @@ export default function Teams() {
 
     const newFilteredTeams: TeamsByStructure = {};
     for (const key in teams) {
-      newFilteredTeams[key] = teams[key].filter(team => team.name.includes(teamSearched));
+      newFilteredTeams[key] = teams[key].filter(team => team.name.toLowerCase().includes(teamSearched.toLowerCase()));
     }
 
     setFilteredTeams(newFilteredTeams);

--- a/src/app/dashboard/visor/teams/page.tsx
+++ b/src/app/dashboard/visor/teams/page.tsx
@@ -2,6 +2,7 @@
 
 import Header from "@/components/Header";
 import TeamsOfAStructure, { fakeTeams } from "@/components/visor/teams/TeamsOfAStructure";
+import { ESTRUCTURAS } from "@/configs/catalogs/visorCatalog";
 import { Button, Dropdown, DropdownItem, DropdownTrigger, DropdownMenu, Input } from "@nextui-org/react";
 import { useEffect, useMemo, useState } from "react";
 
@@ -16,6 +17,8 @@ interface Team {
   pointTypesIDs: string[]
   geographicConf: GeoConfig
 }
+
+// TODO: Use ids
 interface TeamsByStructure {
   territorial: Team[]
   gubernamental: Team[]
@@ -44,6 +47,7 @@ export default function Teams() {
 
     const teamsByStructure = {
       ...teams,
+      // TODO: Use Ids
       territorial: resBody.data.map((structure: Structure) => { if (structure.structureType == "Territorial") return structure.teams; })[0],
       gubernamental: resBody.data.map((structure: Structure) => { if (structure.structureType == "Gubernamental") return structure.teams; })[0],
       campaign: resBody.data.map((structure: Structure) => { if (structure.structureType == "Campaña") return structure.teams; })[0],
@@ -71,6 +75,7 @@ export default function Teams() {
       return;
     }
 
+    // TODO: Use ids
     setFilteredTeams({
       territorial: teams.territorial?.filter(team => team.name.includes(teamSearched)),
       campaign: teams.campaign?.filter(team => team.name.includes(teamSearched)),
@@ -105,10 +110,9 @@ export default function Teams() {
               onSelectionChange={(value) => setSelectedStructuresKeys([...(value as Set<string>)])}
               closeOnSelect={false}
             >
-              <DropdownItem key="Territorial">Territorial</DropdownItem>
-              <DropdownItem key="Gubernamental">Gubernamental</DropdownItem>
-              <DropdownItem key="Dia_D">Dia D</DropdownItem>
-              <DropdownItem key="Campaña">Campaña</DropdownItem>
+              {ESTRUCTURAS.map((str) => {
+                return <DropdownItem key={str.id}>{str.nombre}</DropdownItem>;
+              })}
             </DropdownMenu>
           </Dropdown>
         </div>
@@ -118,25 +122,30 @@ export default function Teams() {
         filteredTeams ? (
           <div className="flex-1 flex flex-col gap-8">
             {
-              (selectedStructures.includes("Territorial") || selectedStructures.length == 0)
+              (selectedStructures.includes("territorial") || selectedStructures.length == 0)
               &&
-              <TeamsOfAStructure structureName="Territorial" teams={filteredTeams.territorial} />
+              <TeamsOfAStructure structureId="territorial" teams={filteredTeams.territorial} />
             }
             {
               (selectedStructures.includes("Campaña") || selectedStructures.length == 0)
               &&
-              <TeamsOfAStructure structureName="Campaña" teams={filteredTeams.campaign} />
+              <TeamsOfAStructure structureId="Campaña" teams={filteredTeams.campaign} />
             }
             {
               (selectedStructures.includes("Gubernamental") || selectedStructures.length == 0)
               &&
-              <TeamsOfAStructure structureName="Gubernamental" teams={filteredTeams.gubernamental} />
+              <TeamsOfAStructure structureId="Gubernamental" teams={filteredTeams.gubernamental} />
             }
             {
               (selectedStructures.includes("Dia D") || selectedStructures.length == 0)
               &&
-              <TeamsOfAStructure structureName="Dia D" teams={filteredTeams.diaD} />
+              <TeamsOfAStructure structureId="Dia D" teams={filteredTeams.diaD} />
             }
+            {/* TODO: Corregir para adaptar a catalogos */}
+            {/* {ESTRUCTURAS.map((str) => {
+              if(selectedStructures.includes("Gubernamental") || selectedStructures.length == 0) return null;
+              return <TeamsOfAStructure key={str.id} structureId={str.nombre} teams={filteredTeams[str.id]} />;
+            })} */}
           </div>
         ) : (
           <div className="flex flex-1 justify-center items-center">

--- a/src/components/visor/teams/TeamModal.tsx
+++ b/src/components/visor/teams/TeamModal.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button, Input, Tabs, Tab, Select, SelectItem, Autocomplete } from "@nextui-org/react";
+import React, { useState, useEffect } from "react";
+import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button, Input, Tabs, Tab, Select, SelectItem, Autocomplete} from "@nextui-org/react";
 import { TIPOS_PUNTO, CONFIGURACIONES_GEOGRAFICAS } from "../../../configs/catalogs/visorCatalog";
 
 interface CoordinationAssistant {
@@ -17,54 +17,122 @@ interface Member {
   name: string;
 }
 
+interface GeographicValue {
+  key: string;
+  name: string;
+}
+
 interface TeamModalProps {
   structureName: string;
 }
 
-
 const TeamModal: React.FC<TeamModalProps> = ({ structureName }) => {
+  // Estados para manejar las distintas variables del modal
   const [isOpen, setIsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<string>("Jerarquia");
   const [selectedGeographicValues, setSelectedGeographicValues] = useState<string[]>([]);
   const [selectedPointTypes, setSelectedPointTypes] = useState<string[]>([]);
-  const [selectedTeamMembers, setSelectedTeamMembers] = useState<string[]>([]);
+  const [selectedAssistant, setSelectedAssistant] = useState<string>("");
+  const [selectedTeamMembers, setSelectedTeamMembers] = useState<Member[]>([]);
   const [coordinationAssistants, setCoordinationAssistants] = useState<CoordinationAssistant[]>([]);
   const [links, setLinks] = useState<Link[]>([]);
   const [members, setMembers] = useState<Member[]>([]);
+  const [filteredMembers, setFilteredMembers] = useState<Member[]>([]);
   const [teamName, setTeamName] = useState<string>("");
+  const [selectedLink, setSelectedLink] = useState<string | null>(null);
+  const [selectedGeographicLevel, setSelectedGeographicLevel] = useState<string>("");
+  const [geographicValues, setGeographicValues] = useState<GeographicValue[]>([]);
 
   const tabs = ["Jerarquia", "Tipo de punto", "Participantes"];
 
-  // useEffect(() => {
-  //   const fetchData = async () => {
-  //     try {
-  //       const [coordinationRes, linksRes, membersRes] = await Promise.all([
-  //         fetch('/api/coordinationAssistants'),
-  //         fetch('/api/links'),
-  //         fetch('/api/members')
-  //       ]);
+  // useEffect para obtener los auxiliares de coordinación
+  useEffect(() => {
+    const fetchCoordinationAssistants = async () => {
+      try {
+        const res = await fetch('/dashboard/api/visor/auxiliaries?estructura=territorial');
+        const result = await res.json();
+        if (result.code === "OK") {
+          const formattedData = result.data.map((item: any) => ({
+            key: item.id,
+            name: item.fullName
+          }));
+          setCoordinationAssistants(formattedData);
+        } else {
+          console.error("Error fetching coordination assistants:", result.message);
+        }
+      } catch (error) {
+        console.error("Error fetching coordination assistants:", error);
+      }
+    };
 
-  //       const [coordinationData, linksData, membersData] = await Promise.all([
-  //         coordinationRes.json(),
-  //         linksRes.json(),
-  //         membersRes.json()
-  //       ]);
+    fetchCoordinationAssistants();
+  }, []);
 
-  //       setCoordinationAssistants(coordinationData);
-  //       setLinks(linksData);
-  //       setMembers(membersData);
-  //     } catch (error) {
-  //       console.error("Error fetching data:", error);
-  //     }
-  //   };
+  // useEffect para obtener los caminantes
+  useEffect(() => {
+    const fetchCaminantes = async () => {
+      try {
+        const res = await fetch('/dashboard/api/visor/caminantes?team=false');
+        const result = await res.json();
+        if (result.code === "OK") {
+          const formattedData = result.data.map((item: any) => ({
+            key: item.id,
+            name: item.User.Person.name
+          }));
+          setMembers(formattedData);
+          setLinks(formattedData);
+          setFilteredMembers(formattedData);
+        } else {
+          console.error("Error fetching caminantes:", result.message);
+        }
+      } catch (error) {
+        console.error("Error fetching caminantes:", error);
+      }
+    };
 
-  //   fetchData();
-  // }, []);
+    fetchCaminantes();
+  }, []);
 
+  // useEffect para filtrar los miembros en base al enlace seleccionado
+  useEffect(() => {
+    if (selectedLink) {
+      setFilteredMembers(members.filter(member => member.key !== selectedLink));
+    } else {
+      setFilteredMembers(members);
+    }
+  }, [selectedLink, members]);
+
+  // useEffect para obtener los valores geográficos en base al nivel seleccionado
+  useEffect(() => {
+    const fetchGeographicValues = async () => {
+      if (selectedGeographicLevel === "") return;
+      
+      try {
+        const res = await fetch(`/dashboard/api/visor/geographicConfiguration?geographicLevel=${selectedGeographicLevel}&municipios=667bcf8e6ae4f348d52a3af1`);
+        const result = await res.json();
+        if (result.code === "OK") {
+          const formattedData = result.data.map((item: any) => ({
+            key: item.id,
+            name: item.name
+          }));
+          setGeographicValues(formattedData);
+        } else {
+          console.error("Error fetching geographic values:", result.message);
+        }
+      } catch (error) {
+        console.error("Error fetching geographic values:", error);
+      }
+    };
+
+    fetchGeographicValues();
+  }, [selectedGeographicLevel]);
+
+  // Maneja el cambio de tab en el modal
   const handleTabChange = (key: React.Key) => {
     setActiveTab(key as string);
   };
 
+  // Maneja el botón de siguiente para cambiar de tab o enviar el formulario
   const handleNext = () => {
     const currentIndex = tabs.indexOf(activeTab);
     if (currentIndex < tabs.length - 1) {
@@ -74,64 +142,82 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureName }) => {
     }
   };
 
+  // Maneja la selección de valores geográficos
   const handleGeographicValueSelectionChange = (key: React.Key) => {
     if (!selectedGeographicValues.includes(key as string)) {
       setSelectedGeographicValues([...selectedGeographicValues, key as string]);
     }
   };
 
+  // Maneja la selección de tipos de punto
   const handlePointTypeSelectionChange = (key: React.Key) => {
     if (!selectedPointTypes.includes(key as string)) {
       setSelectedPointTypes([...selectedPointTypes, key as string]);
     }
   };
 
+  // Maneja la selección de miembros del equipo
   const handleTeamMemberSelectionChange = (key: React.Key) => {
-    if (!selectedTeamMembers.includes(key as string)) {
-      setSelectedTeamMembers([...selectedTeamMembers, key as string]);
+    const selectedMember = filteredMembers.find(member => member.key === key);
+    if (selectedMember && !selectedTeamMembers.includes(selectedMember)) {
+      setSelectedTeamMembers([...selectedTeamMembers, selectedMember]);
     }
   };
 
+  // Maneja la selección de enlace
+  const handleLinkSelectionChange = (key: React.Key) => {
+    setSelectedLink(key as string);
+  };
+
+  // Maneja la selección de nivel geográfico
+  const handleGeographicLevelSelectionChange = (key: React.Key) => {
+    setSelectedGeographicLevel(key as string);
+    setSelectedGeographicValues([]); // Limpiar valores geográficos anteriores
+  };
+
+  // Elimina un valor geográfico seleccionado
   const handleRemoveGeographicValue = (key: string) => {
     setSelectedGeographicValues(selectedGeographicValues.filter((value) => value !== key));
   };
 
+  // Elimina un miembro del equipo seleccionado
   const handleRemoveTeamMember = (key: string) => {
-    setSelectedTeamMembers(selectedTeamMembers.filter((member) => member !== key));
+    setSelectedTeamMembers(selectedTeamMembers.filter((member) => member.key !== key));
   };
 
+  // Maneja el envío del formulario para crear el equipo
   const handleSubmit = async () => {
     const teamData = {
       name: teamName,
       pointTypesIDs: selectedPointTypes,
       geographicConf: {
-        geographicLevel: selectedGeographicValues[0], // Assuming you select only one geographic level
-        values: selectedGeographicValues.slice(1), // Remaining selected values
+        geographicLevel: selectedGeographicLevel,
+        values: selectedGeographicValues,
       },
-      members: selectedTeamMembers,
+      auxiliaryId: selectedAssistant,
+      linkId: selectedLink,
+      caminantes: selectedTeamMembers.map(member => member.key),
     };
 
     // try {
-    //   const res = await fetch('/api/createTeam', {
+    //   const res = await fetch('/dashboard/api/visor/team', {
     //     method: 'POST',
     //     headers: {
-    //       'Content-Type': 'application/json'
+    //       'Content-Type': 'application/json',
     //     },
-    //     body: JSON.stringify(teamData)
+    //     body: JSON.stringify(teamData),
     //   });
-
     //   const result = await res.json();
-
     //   if (result.code === "OK") {
-    //     console.log("Team created successfully");
-    //     setIsOpen(false);
+    //     console.log("Team created successfully:", result.data);
     //   } else {
-    //     console.error("Error creating team:", result.statusText);
+    //     console.error("Error creating team:", result.message);
     //   }
     // } catch (error) {
     //   console.error("Error creating team:", error);
     // }
     console.log(teamData);
+    
   };
 
   return (
@@ -158,6 +244,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureName }) => {
                     label="Auxiliar de Coordinación"
                     placeholder="Selecciona al auxiliar"
                     isRequired
+                    onSelectionChange={(key) => setSelectedAssistant(key as string)}
                   >
                     {coordinationAssistants.map((assistant) => (
                       <SelectItem key={assistant.key} value={assistant.key}>
@@ -180,19 +267,20 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureName }) => {
                     placeholder="Selecciona los tipos de punto"
                     isRequired
                     selectionMode="multiple"
-                    onSelectionChange={(_key) => handlePointTypeSelectionChange} // la variable _key no se está usando
+                    onSelectionChange={(_key) => handlePointTypeSelectionChange}
                   >
-                    {TIPOS_PUNTO.map((type) => (
-                      <SelectItem key={type.id} value={type.id}>
-                        {type.nombre}
+                    {TIPOS_PUNTO.map((pointType) => (
+                      <SelectItem key={pointType.id} value={pointType.id}>
+                        {pointType.nombre}
                       </SelectItem>
                     ))}
                   </Select>
-                  <p className="text-sm text-gray-500 px-1">Zona de trabajo</p>
+                  <p className="py-2">Niveles Geográficos</p>
                   <Select
-                    label="Nivel geográfico"
-                    placeholder="Seleccione el nivel geográfico"
+                    label="Nivel Geográfico"
+                    placeholder="Selecciona el nivel geográfico"
                     isRequired
+                    onSelectionChange={(_key) => handleGeographicLevelSelectionChange}
                   >
                     {CONFIGURACIONES_GEOGRAFICAS.map((level) => (
                       <SelectItem key={level.id} value={level.id}>
@@ -206,9 +294,9 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureName }) => {
                     isRequired
                     onSelectionChange={handleGeographicValueSelectionChange}
                   >
-                    {CONFIGURACIONES_GEOGRAFICAS.map((value) => (
-                      <SelectItem key={value.id} value={value.id}>
-                        {value.nombre}
+                    {geographicValues.map((value) => (
+                      <SelectItem key={value.key} value={value.key}>
+                        {value.name}
                       </SelectItem>
                     ))}
                   </Autocomplete>
@@ -228,6 +316,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureName }) => {
                     label="Enlace"
                     placeholder="Selecciona el enlace"
                     isRequired
+                    onSelectionChange={handleLinkSelectionChange}
                   >
                     {links.map((link) => (
                       <SelectItem key={link.key} value={link.key}>
@@ -241,7 +330,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureName }) => {
                     isRequired
                     onSelectionChange={handleTeamMemberSelectionChange}
                   >
-                    {members.map((member) => (
+                    {filteredMembers.map((member) => (
                       <SelectItem key={member.key} value={member.key}>
                         {member.name}
                       </SelectItem>
@@ -249,9 +338,9 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureName }) => {
                   </Autocomplete>
                   <div className={`mt-4 ${selectedTeamMembers.length > 4 ? "overflow-y-scroll h-24" : ""} px-8 flex flex-col gap-2`}>
                     {selectedTeamMembers.map((member) => (
-                      <div key={member} className="flex justify-between items-center py-2 px-4 rounded-md bg-content2">
-                        <span>{member}</span>
-                        <Button isIconOnly className="material-symbols-outlined bg-transparent hover:bg-accent hover:text-white" size="sm" onClick={() => handleRemoveTeamMember(member)}>close</Button>
+                      <div key={member.key} className="flex justify-between items-center py-2 px-4 rounded-md bg-content2">
+                        <span>{member.name}</span>
+                        <Button isIconOnly className="material-symbols-outlined bg-transparent hover:bg-accent hover:text-white" size="sm" onClick={() => handleRemoveTeamMember(member.key)}>close</Button>
                       </div>
                     ))}
                   </div>

--- a/src/components/visor/teams/TeamModal.tsx
+++ b/src/components/visor/teams/TeamModal.tsx
@@ -28,6 +28,11 @@ interface TeamModalProps {
   structureId: string;
 }
 
+interface TypePoint {
+  key: string,
+  name: string,
+}
+
 const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<string>("Jerarquia");
@@ -60,7 +65,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
           }));
           setCoordinationAssistants(formattedData);
           console.log(formattedData);
-          
+
         } else {
           console.error("Error fetching coordination assistants:", result.message);
         }
@@ -70,7 +75,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
     };
 
     fetchCoordinationAssistants();
-  }, []);
+  }, [structureId]);
 
   useEffect(() => {
     const fetchCaminantes = async () => {
@@ -106,30 +111,30 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
 
   useEffect(() => {
     const fetchGeographicValues = async () => {
-      
-      
+
+
 
       if (selectedGeographicLevel === "") return;
 
       const currentAssistant = coordinationAssistants.find((assistant) => assistant.key === selectedAssistant);
-      
+
       try {
-        
+
         // Suponiendo que el currentAssistant tiene una propiedad llamada municipios con los IDs de los municipios
         const municipios = currentAssistant ? currentAssistant.municipiosIDs.join(",") : "667bd16c05c90de30f041144,667bd1aa05c90de30f04114f,667bd1ab05c90de30f04115";
-        
+
         console.log(selectedGeographicLevel);
         // console.log([...selectedGeographicLevel][0]);
-        
+
         console.log(municipios);
-        
-        
+
+
 
         const res = await fetch(`/dashboard/api/visor/geographicConfiguration?geographicLevel=${selectedGeographicLevel}&municipios=${municipios}`);
         const result = await res.json();
 
         console.log(result);
-        
+
         if (result.code === "OK") {
           const formattedData = result.data.map((item: any) => ({
             key: item.id,
@@ -166,11 +171,11 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
     }
   };
 
-  const handlePointTypeSelectionChange = (key: React.Key) => {
-    if (!selectedPointTypes.includes(key as string)) {
-      setSelectedPointTypes([...selectedPointTypes, key as string]);
-    }
+  const handlePointTypeSelectionChange = (keys: Set<React.Key>) => {
+    const selectedKeysArray = Array.from(keys);
+    setSelectedPointTypes(selectedKeysArray.map(key => key as string));
   };
+
 
   const handleTeamMemberSelectionChange = (key: React.Key) => {
     const selectedMember = filteredMembers.find(member => member.key === key);
@@ -184,11 +189,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
   };
 
   const handleGeographicLevelSelectionChange = (key: string) => {
-    // setSelectedGeographicLevel(key as string);
     setSelectedGeographicLevel([...key][0]);
-    // key.toString() returns [object Set] instead of its value, please fix this
-
-
     setSelectedGeographicValues([]);
   };
 
@@ -232,6 +233,13 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
     } catch (error) {
       console.error("Error creating team:", error);
     }
+  };
+
+
+
+  const getGeographicValueName = (key: string) => {
+    const value = geographicValues.find(val => val.key === key);
+    return value ? value.name : key;
   };
 
   return (
@@ -282,7 +290,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
                     placeholder="Selecciona los tipos de punto"
                     isRequired
                     selectionMode="multiple"
-                    onSelectionChange={(_key) => handlePointTypeSelectionChange}
+                    onSelectionChange={(keys) => handlePointTypeSelectionChange(keys as Set<React.Key>)}
                   >
                     {TIPOS_PUNTO.filter((tp) => tp.estructuraId === structureId).map((pointType) => (
                       <SelectItem key={pointType.id} value={pointType.id}>
@@ -318,7 +326,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
                   <div className={`${selectedGeographicValues.length > 4 ? "overflow-y-scroll h-24" : ""} px-8 flex flex-col gap-2`}>
                     {selectedGeographicValues.map((value) => (
                       <div key={value} className="flex justify-between items-center py-2 px-4 rounded-md bg-content2">
-                        <span className="text-sm">{value}</span>
+                        <span className="text-sm">{getGeographicValueName(value)}</span>
                         <Button isIconOnly className="material-symbols-outlined bg-transparent hover:bg-accent hover:text-white" size="sm" onClick={() => handleRemoveGeographicValue(value)}>close</Button>
                       </div>
                     ))}

--- a/src/components/visor/teams/TeamModal.tsx
+++ b/src/components/visor/teams/TeamModal.tsx
@@ -55,9 +55,12 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
         if (result.code === "OK") {
           const formattedData = result.data.map((item: any) => ({
             key: item.id,
-            name: item.fullName
+            name: item.fullName,
+            municipiosIDs: item.municipiosIDs,
           }));
           setCoordinationAssistants(formattedData);
+          console.log(formattedData);
+          
         } else {
           console.error("Error fetching coordination assistants:", result.message);
         }
@@ -67,7 +70,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
     };
 
     fetchCoordinationAssistants();
-  }, [structureId]);
+  }, []);
 
   useEffect(() => {
     const fetchCaminantes = async () => {
@@ -103,16 +106,30 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
 
   useEffect(() => {
     const fetchGeographicValues = async () => {
+      
+      
+
       if (selectedGeographicLevel === "") return;
 
       const currentAssistant = coordinationAssistants.find((assistant) => assistant.key === selectedAssistant);
-
+      
       try {
+        
         // Suponiendo que el currentAssistant tiene una propiedad llamada municipios con los IDs de los municipios
         const municipios = currentAssistant ? currentAssistant.municipiosIDs.join(",") : "667bd16c05c90de30f041144,667bd1aa05c90de30f04114f,667bd1ab05c90de30f04115";
+        
+        console.log(selectedGeographicLevel);
+        // console.log([...selectedGeographicLevel][0]);
+        
+        console.log(municipios);
+        
+        
 
         const res = await fetch(`/dashboard/api/visor/geographicConfiguration?geographicLevel=${selectedGeographicLevel}&municipios=${municipios}`);
         const result = await res.json();
+
+        console.log(result);
+        
         if (result.code === "OK") {
           const formattedData = result.data.map((item: any) => ({
             key: item.id,
@@ -166,8 +183,12 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
     setSelectedLink(key as string);
   };
 
-  const handleGeographicLevelSelectionChange = (key: React.Key) => {
-    setSelectedGeographicLevel(key as string);
+  const handleGeographicLevelSelectionChange = (key: string) => {
+    // setSelectedGeographicLevel(key as string);
+    setSelectedGeographicLevel([...key][0]);
+    // key.toString() returns [object Set] instead of its value, please fix this
+
+
     setSelectedGeographicValues([]);
   };
 
@@ -194,23 +215,23 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
 
     console.log(teamData);
 
-    // try {
-    //   const res = await fetch('/dashboard/api/visor/team', {
-    //     method: 'POST',
-    //     headers: {
-    //       'Content-Type': 'application/json',
-    //     },
-    //     body: JSON.stringify(teamData),
-    //   });
-    //   const result = await res.json();
-    //   if (result.code === "OK") {
-    //     console.log("Team created successfully:", result.data);
-    //   } else {
-    //     console.error("Error creating team:", result.message);
-    //   }
-    // } catch (error) {
-    //   console.error("Error creating team:", error);
-    // }
+    try {
+      const res = await fetch("/dashboard/api/visor/teams", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(teamData),
+      });
+      const result = await res.json();
+      if (result.code === "OK") {
+        console.log("Team created successfully:", result.data);
+      } else {
+        console.error("Error creating team:", result.message);
+      }
+    } catch (error) {
+      console.error("Error creating team:", error);
+    }
   };
 
   return (
@@ -274,7 +295,7 @@ const TeamModal: React.FC<TeamModalProps> = ({ structureId }) => {
                     label="Nivel Geográfico"
                     placeholder="Selecciona el nivel geográfico"
                     isRequired
-                    onSelectionChange={(_key) => handleGeographicLevelSelectionChange}
+                    onSelectionChange={(_key) => handleGeographicLevelSelectionChange(_key as string)}
                   >
                     {CONFIGURACIONES_GEOGRAFICAS.map((level) => (
                       <SelectItem key={level.id} value={level.id}>

--- a/src/components/visor/teams/TeamsOfAStructure.tsx
+++ b/src/components/visor/teams/TeamsOfAStructure.tsx
@@ -2,9 +2,10 @@
 import TeamModal from "./TeamModal";
 import TeamCard from "./TeamCard";
 import { Divider } from "@nextui-org/react";
+import { ESTRUCTURAS } from "@/configs/catalogs/visorCatalog";
 
 interface TeamsOfAStructureProps {
-  structureName: string
+  structureId: string
   teams?: Team[]
 }
 
@@ -21,12 +22,14 @@ interface Team {
   geographicConf: GeoConfig
 }
 
-export default function TeamsOfAStructure({ structureName, teams }: TeamsOfAStructureProps) {
+export default function TeamsOfAStructure({ structureId, teams }: TeamsOfAStructureProps) {
+  const structureName = ESTRUCTURAS.find((str) => str.id === structureId)?.nombre;
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex justify-between items-center">
         <h2 className="text-2xl">Estructura {structureName}</h2>
-        <TeamModal structureName={structureName} />
+        <TeamModal structureId={structureId} />
       </div>
       <Divider />
       <div className="grid grid-cols-2 xl:grid-cols-4 lg:grid-cols-2 justify-items-center gap-6 min-w-full">

--- a/src/configs/catalogs/visorCatalog.ts
+++ b/src/configs/catalogs/visorCatalog.ts
@@ -28,12 +28,12 @@ export interface StatusNecesidades {
 
 export const ESTRUCTURAS = [
   {
-    id: "politica",
-    nombre: "Politica",
-  },
-  {
     id: "territorial",
     nombre: "Territorial",
+  },
+  {
+    id: "politica",
+    nombre: "Politica",
   },
   {
     id: "gobierno",
@@ -93,6 +93,12 @@ export const TIPOS_PUNTO: TiposPunto[] = [
     id: "necesidades",
     nombre: "Necesidades",
     icon: "iconoNecesidad",
+    estructuraId: "territorial"
+  },
+  {
+    id: "publicidad",
+    nombre: "Publicidad",
+    icon: "",
     estructuraId: "territorial"
   },
   {


### PR DESCRIPTION
**In the Team Modal modal:**

- I implemented all the logic so that the modal would function and teams could be created.
- Point types and geographic zones are filtered based on the information that the assistant has.
- Walkers and the link come from the same bucket, but I added logic so that the user who is chosen as the link no longer appears in the members.
- Geographic zones and point types are obtained through the catalog.
- 

**On the teams page:**

- I modified the interface to make it dynamic and work using the IDs of the structures, while also modifying the entire page to use IDs instead of names.