### PR TITLE
feat: Agregue el modal para ver las rondas en el mapa de campo

### DIFF
--- a/src/app/dashboard/base/page.tsx
+++ b/src/app/dashboard/base/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import Header from "@/components/Header";
 import { Card, Skeleton, Button } from "@nextui-org/react";
+import RoundsModal from "@/components/visor/teams/RoundsModal";
 
 export default function BasePlatformWelcome() {
   const [isLoaded, setIsLoaded] = useState(false);

--- a/src/app/dashboard/visor/teams/[id]/rounds/page.tsx
+++ b/src/app/dashboard/visor/teams/[id]/rounds/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Button, Divider } from "@nextui-org/react";
 import RoundsCard from "@/components/visor/teams/RoundsCard";
 import { useParams } from "next/navigation";
+import RoundsModal from "@/components/visor/teams/RoundsModal";
 
 interface Round {
   id: string;
@@ -84,6 +85,7 @@ export default function RoundsPage() {
 
   return (
     <div className="flex flex-col p-8 gap-8">
+      <RoundsModal/>
       {alertMessage && (
         <div className="alert alert-warning flex justify-between items-center p-4 mb-4 text-sm text-yellow-700 bg-yellow-100 rounded-lg" role="alert">
           <span>{alertMessage}</span>

--- a/src/components/visor/teams/RoundsCard.tsx
+++ b/src/components/visor/teams/RoundsCard.tsx
@@ -9,7 +9,14 @@ interface RoundsCardProps {
   showEditDeleteButtons?: boolean; // Nueva prop opcional
 }
 
-export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusChange, showEditDeleteButtons = true }: RoundsCardProps) {
+export default function RoundsCard({
+  id,
+  name,
+  status,
+  pointTypesIDs,
+  onStatusChange,
+  showEditDeleteButtons = true,
+}: RoundsCardProps) {
   const getClassNames = () => {
     switch (status) {
       case "activa":
@@ -51,7 +58,7 @@ export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusCh
   };
 
   const handlePlay = () => {
-    if (status === "pausada") {
+    if (status === "pausada" || status === "noiniciada") {
       updateStatus("start");
     }
   };
@@ -68,7 +75,10 @@ export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusCh
         <h1 className="text-2xl">{name}</h1>
       </div>
       <div className="flex-1 text-center">
-        <p className="text-sm">{pointTypesIDs.slice(0, 3).join(", ")}{pointTypesIDs.length > 3 && "..."}</p>
+        <p className="text-sm">
+          {pointTypesIDs.slice(0, 3).join(", ")}
+          {pointTypesIDs.length > 3 && "..."}
+        </p>
       </div>
       <div className="flex flex-row gap-4 justify-end flex-1">
         {status === "activa" && (
@@ -85,6 +95,11 @@ export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusCh
               <span className="material-symbols-outlined">play_arrow</span>
             </Button>
           </>
+        )}
+        {status === "noiniciada" && (
+          <Button isIconOnly aria-label="Reproducir" color="default" variant="light" size="md" onPress={handlePlay}>
+            <span className="material-symbols-outlined">play_arrow</span>
+          </Button>
         )}
         {status === "noiniciada" && showEditDeleteButtons && (
           <>

--- a/src/components/visor/teams/RoundsCard.tsx
+++ b/src/components/visor/teams/RoundsCard.tsx
@@ -6,9 +6,10 @@ interface RoundsCardProps {
   status: "activa" | "pausada" | "noiniciada";
   pointTypesIDs: string[];
   onStatusChange: (id: string, newStatus: "activa" | "pausada" | "noiniciada") => void;
+  showEditDeleteButtons?: boolean; // Nueva prop opcional
 }
 
-export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusChange }: RoundsCardProps) {
+export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusChange, showEditDeleteButtons = true }: RoundsCardProps) {
   const getClassNames = () => {
     switch (status) {
       case "activa":
@@ -62,7 +63,7 @@ export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusCh
   };
 
   return (
-    <Card key={id} className={`flex flex-row w-full p-4 gap-2 items-center ${getClassNames()}`}>
+    <Card key={id} className={`flex flex-col sm:flex-row w-full p-4 gap-2 items-center ${getClassNames()}`}>
       <div className="flex-1">
         <h1 className="text-2xl">{name}</h1>
       </div>
@@ -85,7 +86,7 @@ export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusCh
             </Button>
           </>
         )}
-        {status === "noiniciada" && (
+        {status === "noiniciada" && showEditDeleteButtons && (
           <>
             <Button isIconOnly aria-label="Eliminar" color="danger" variant="light" size="md" onPress={() => { /* Lógica para eliminar */ }}>
               <span className="material-symbols-outlined">delete</span>

--- a/src/components/visor/teams/RoundsModal.tsx
+++ b/src/components/visor/teams/RoundsModal.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button, Divider } from "@nextui-org/react";
+import RoundsCard from "@/components/visor/teams/RoundsCard";
+import { useParams } from "next/navigation";
+
+interface Round {
+  id: string;
+  name: string;
+  status: "activa" | "pausada" | "noiniciada";
+  pointTypesIDs: string[];
+}
+
+interface Rounds {
+  active: Round[];
+  paused: Round[];
+  noStarted: Round[];
+}
+
+export default function RoundsModal() {
+  const { id: teamId } = useParams();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [rounds, setRounds] = useState<Rounds>({
+    active: [],
+    noStarted: [],
+    paused: []
+  });
+
+  const toggleExpand = () => {
+    setIsExpanded(prev => !prev);
+  };
+
+  const getRounds = async () => {
+    try {
+      console.log(`Fetching rounds for teamId: ${teamId}`);
+      const response = await fetch(`/dashboard/api/visor/teams/${teamId}/rounds`);
+      const data = await response.json();
+
+      if (data.code === "OK" && data.data) {
+        console.log("Fetched rounds:", data.data);
+        const activeRounds = data.data.active;
+        const pausedRounds = data.data.paused;
+        const noStartedRounds = data.data.noStarted;
+        console.log("Active rounds:", activeRounds);
+        console.log("Paused rounds:", pausedRounds);
+        console.log("No started rounds:", noStartedRounds);
+        setRounds({
+          active: activeRounds,
+          paused: pausedRounds,
+          noStarted: noStartedRounds
+        });
+      } else {
+        console.error(data.message);
+      }
+    } catch (error) {
+      console.error("Error fetching rounds:", error);
+    }
+  };
+
+  useEffect(() => {
+    console.log(`Component mounted, teamId: ${teamId}`);
+    if (teamId) {
+      getRounds();
+    }
+  }, [teamId]);
+
+  const handleStatusChange = () => {
+    getRounds();
+  };
+
+  return (
+    <div className="relative mx-auto w-full max-w-[740px] transition-all duration-500">
+      <div className="absolute left-1/2 top-0 transform -translate-x-1/2 -translate-y-1/2">
+        <Button
+          isIconOnly
+          color="default"
+          variant="light"
+          size="md"
+          onPress={toggleExpand}
+        >
+          <span className="material-symbols-outlined">
+            {isExpanded ? "arrow_circle_up" : "arrow_circle_down"}
+          </span>
+        </Button>
+      </div>
+      <div className={`transition-all duration-500 overflow-hidden ${isExpanded ? "h-[600px] pt-8 overflow-y-auto" : "h-0"}`}>
+        {isExpanded && (
+          <div className="p-4">
+            {rounds.paused.length > 0 && (
+              <div className="flex flex-col gap-4 w-full">
+                <h1 className="text-3xl">Rondas Pausadas</h1>
+                <div>
+                  {rounds.paused.map(pausedRound => (
+                    <RoundsCard
+                      key={pausedRound.id}
+                      id={pausedRound.id}
+                      name={pausedRound.name}
+                      status={pausedRound.status}
+                      pointTypesIDs={pausedRound.pointTypesIDs}
+                      onStatusChange={handleStatusChange}
+                    />
+                  ))}
+                </div>
+                <Divider />
+              </div>
+            )}
+            {rounds.noStarted.length > 0 && (
+              <div className="flex flex-col gap-4 w-full">
+                <div className="flex flex-row justify-between">
+                  <h1 className="text-3xl">Futuras Rondas</h1>
+                </div>
+                <div className="flex flex-col gap-4">
+                  {rounds.noStarted.map(round => (
+                    <RoundsCard
+                      key={round.id}
+                      id={round.id}
+                      name={round.name}
+                      status={round.status}
+                      pointTypesIDs={round.pointTypesIDs}
+                      onStatusChange={handleStatusChange}
+                      showEditDeleteButtons={false}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/visor/teams/RoundsModal.tsx
+++ b/src/components/visor/teams/RoundsModal.tsx
@@ -87,6 +87,24 @@ export default function RoundsModal() {
       <div className={`transition-all duration-500 overflow-hidden ${isExpanded ? "h-[600px] pt-8 overflow-y-auto" : "h-0"}`}>
         {isExpanded && (
           <div className="p-4">
+            {rounds.active.length > 0 && (
+              <div className="flex flex-col gap-4 w-full">
+                <h1 className="text-3xl">Rondas Activas</h1>
+                <div>
+                  {rounds.active.map(activeRound => (
+                    <RoundsCard
+                      key={activeRound.id}
+                      id={activeRound.id}
+                      name={activeRound.name}
+                      status={activeRound.status}
+                      pointTypesIDs={activeRound.pointTypesIDs}
+                      onStatusChange={handleStatusChange}
+                    />
+                  ))}
+                </div>
+                <Divider />
+              </div>
+            )}
             {rounds.paused.length > 0 && (
               <div className="flex flex-col gap-4 w-full">
                 <h1 className="text-3xl">Rondas Pausadas</h1>
@@ -119,7 +137,7 @@ export default function RoundsModal() {
                       status={round.status}
                       pointTypesIDs={round.pointTypesIDs}
                       onStatusChange={handleStatusChange}
-                      showEditDeleteButtons={false}
+                      showEditDeleteButtons={false} // Se pasa la prop para ocultar botones de editar y eliminar
                     />
                   ))}
                 </div>


### PR DESCRIPTION
Agregue el modal para ver las rondas del mapa de campo y realice lo siguiente:

- Componente para el Menu de mapa de campo.
- Para interactuar con las rondas
- Activar/pausar la ronda activa
- Si no hay ronda activa, iniciar una ronda futura
- Conectado todo
- Recibe el id del equipo
- Funcional y Listo para ser montado después en el mapa de campo ( solo el componente listo para ponerse en cualquier lado)

Boton para expandir el modal:
![image](https://github.com/user-attachments/assets/36711b94-937e-458f-aaf7-6acfd47937dd)

Una vez se expande el modal se ven las rondas que hay, si no hay rondas activas o pausadas ese titulo no se muestra
![image](https://github.com/user-attachments/assets/8560d0d2-f83e-4847-b45c-31fbfb90db45)

Se cambia el status de la ronda al darle click a los botones para pausar o activar una ronda
![image](https://github.com/user-attachments/assets/c5bdad79-f3bd-4a7b-87ce-5a9b34c64cd2)
