### PR TITLE
Checkpoints visits

### DIFF
--- a/src/app/dashboard/api/visor/checkpoints/[id]/route.ts
+++ b/src/app/dashboard/api/visor/checkpoints/[id]/route.ts
@@ -1,0 +1,45 @@
+import prisma from "@/configs/database";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const id = params.id;
+    const { userId } = await request.json();
+
+    if (!userId) {
+      return NextResponse.json({ code: "INCOMPLETE_FIELDS", message: "Incomplete fields" });
+    }
+
+    const checkpoint = await prisma.visor_CheckPoint.findFirst({
+      where: { id }
+    });
+
+    if (!checkpoint) {
+      return NextResponse.json({ code: "NOT_FOUND", message: "Checkpoint not found" });
+    }
+
+    // Verify if user already registered
+    const userChecked = checkpoint.visitedBy.find((v) => v.userId === userId);
+
+    if (userChecked) {
+      return NextResponse.json({ code: "ALREADY_CHECKED", message: "User already registered" });
+    }
+
+    const visitedByUpdate = await prisma.visor_CheckPoint.update({
+      where: { id },
+      data: {
+        visitedBy: {
+          set: [
+            ...checkpoint.visitedBy,
+            { userId, date: new Date() }
+          ]
+        }
+      }
+    });
+
+    return NextResponse.json({ code: "OK", message: "Checkpoint updated successfully", data: visitedByUpdate });
+  } catch (error) {
+    console.log(error);
+    return NextResponse.json({ code: "ERROR", message: "An error occurred" });
+  }
+}

--- a/src/app/dashboard/api/visor/rounds/[id]/route.ts
+++ b/src/app/dashboard/api/visor/rounds/[id]/route.ts
@@ -69,7 +69,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
 async function startRound(roundId: string) {
   const currentRound = await prisma.visor_Round.findUnique({
     where: {
-      id: roundId
+      id: roundId, active: true
     }
   });
 

--- a/src/app/dashboard/api/visor/rounds/[id]/route.ts
+++ b/src/app/dashboard/api/visor/rounds/[id]/route.ts
@@ -73,6 +73,10 @@ async function startRound(roundId: string) {
     }
   });
 
+  if (!currentRound) {
+    return null;
+  }
+
   // Check that there are no active rounds
   const activeRounds = await prisma.visor_Round.aggregate({
     _count: {


### PR DESCRIPTION
Se actualiza la lista de objetos de visitas del checkpoint sobre la ruta /dashboard/api/checkpoints/:id
Se hizo con ruta PATCH, que recibe "userId" en el body
Si el usuario ya se encuentra en la lista se devuelve code response "ALREADY_CHECKED"
Si no existe lo agrega a la lista de visitantes
La fecha de visita la agrega el servidor, solo es necesario pasar el id del usuario como "userId".

Vi que en la ruta de rondas para activar la ronda falto una validación de active y que devolviera null si la ronda no existe, ya quedo listo eso