### PR TITLE
Añadi el menu de tipos de punto en el modal del mapa de campo

### DIFF
--- a/src/app/dashboard/base/page.tsx
+++ b/src/app/dashboard/base/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import Header from "@/components/Header";
 import { Card, Skeleton, Button } from "@nextui-org/react";
+import RoundsModal from "@/components/visor/teams/RoundsModal";
 
 export default function BasePlatformWelcome() {
   const [isLoaded, setIsLoaded] = useState(false);

--- a/src/app/dashboard/visor/teams/[id]/rounds/page.tsx
+++ b/src/app/dashboard/visor/teams/[id]/rounds/page.tsx
@@ -85,7 +85,6 @@ export default function RoundsPage() {
 
   return (
     <div className="flex flex-col p-8 gap-8">
-      <RoundsModal/>
       {alertMessage && (
         <div className="alert alert-warning flex justify-between items-center p-4 mb-4 text-sm text-yellow-700 bg-yellow-100 rounded-lg" role="alert">
           <span>{alertMessage}</span>

--- a/src/app/dashboard/visor/teams/[id]/rounds/page.tsx
+++ b/src/app/dashboard/visor/teams/[id]/rounds/page.tsx
@@ -96,6 +96,7 @@ export default function RoundsPage() {
 
       {rounds.active.length > 0 && (
         <div className="flex flex-col gap-4 w-full">
+          <RoundsModal/>
           <h1 className="text-3xl">Ronda Activa</h1>
           <div className="w-full">
             {rounds.active.map((activeRound) =>

--- a/src/app/dashboard/visor/teams/[id]/rounds/page.tsx
+++ b/src/app/dashboard/visor/teams/[id]/rounds/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Button, Divider } from "@nextui-org/react";
 import RoundsCard from "@/components/visor/teams/RoundsCard";
 import { useParams } from "next/navigation";
+import RoundsModal from "@/components/visor/teams/RoundsModal";
 
 interface Round {
   id: string;
@@ -84,6 +85,7 @@ export default function RoundsPage() {
 
   return (
     <div className="flex flex-col p-8 gap-8">
+      <RoundsModal/>
       {alertMessage && (
         <div className="alert alert-warning flex justify-between items-center p-4 mb-4 text-sm text-yellow-700 bg-yellow-100 rounded-lg" role="alert">
           <span>{alertMessage}</span>

--- a/src/components/visor/teams/RoundsCard.tsx
+++ b/src/components/visor/teams/RoundsCard.tsx
@@ -6,6 +6,7 @@ interface RoundsCardProps {
   status: "activa" | "pausada" | "noiniciada";
   pointTypesIDs: string[];
   onStatusChange: (id: string, newStatus: "activa" | "pausada" | "noiniciada") => void;
+  onCardClick?: (id: string) => void; // Nueva prop para manejar clics en la card
   showEditDeleteButtons?: boolean; // Nueva prop opcional
 }
 
@@ -15,6 +16,7 @@ export default function RoundsCard({
   status,
   pointTypesIDs,
   onStatusChange,
+  onCardClick, // Nueva prop
   showEditDeleteButtons = true,
 }: RoundsCardProps) {
   const getClassNames = () => {
@@ -69,8 +71,19 @@ export default function RoundsCard({
     }
   };
 
+  const handleClick = () => {
+    if (status === "activa" && onCardClick) {
+      onCardClick(id);
+    }
+  };
+
   return (
-    <Card key={id} className={`flex flex-col sm:flex-row w-full p-4 gap-2 items-center ${getClassNames()}`}>
+    <Card
+      key={id}
+      className={`flex flex-col sm:flex-row w-full p-4 gap-2 items-center ${getClassNames()}`}
+      isPressable={status === "activa"}
+      onPress={handleClick}
+    >
       <div className="flex-1">
         <h1 className="text-2xl">{name}</h1>
       </div>

--- a/src/components/visor/teams/RoundsCard.tsx
+++ b/src/components/visor/teams/RoundsCard.tsx
@@ -9,7 +9,14 @@ interface RoundsCardProps {
   showEditDeleteButtons?: boolean; // Nueva prop opcional
 }
 
-export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusChange, showEditDeleteButtons = true }: RoundsCardProps) {
+export default function RoundsCard({
+  id,
+  name,
+  status,
+  pointTypesIDs,
+  onStatusChange,
+  showEditDeleteButtons = true,
+}: RoundsCardProps) {
   const getClassNames = () => {
     switch (status) {
       case "activa":
@@ -51,7 +58,7 @@ export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusCh
   };
 
   const handlePlay = () => {
-    if (status === "pausada") {
+    if (status === "pausada" || status === "noiniciada") {
       updateStatus("start");
     }
   };
@@ -68,7 +75,10 @@ export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusCh
         <h1 className="text-2xl">{name}</h1>
       </div>
       <div className="flex-1 text-center">
-        <p className="text-sm">{pointTypesIDs.slice(0, 3).join(", ")}{pointTypesIDs.length > 3 && "..."}</p>
+        <p className="text-sm">
+          {pointTypesIDs.slice(0, 3).join(", ")}
+          {pointTypesIDs.length > 3 && "..."}
+        </p>
       </div>
       <div className="flex flex-row gap-4 justify-end flex-1">
         {status === "activa" && (
@@ -85,6 +95,11 @@ export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusCh
               <span className="material-symbols-outlined">play_arrow</span>
             </Button>
           </>
+        )}
+        {status === "noiniciada" && (
+          <Button isIconOnly aria-label="Reproducir" color="default" variant="light" size="md" onPress={handlePlay}>
+            <span className="material-symbols-outlined">play_arrow</span>
+          </Button>
         )}
         {status === "noiniciada" && showEditDeleteButtons && (
           <>

--- a/src/components/visor/teams/RoundsCard.tsx
+++ b/src/components/visor/teams/RoundsCard.tsx
@@ -6,9 +6,10 @@ interface RoundsCardProps {
   status: "activa" | "pausada" | "noiniciada";
   pointTypesIDs: string[];
   onStatusChange: (id: string, newStatus: "activa" | "pausada" | "noiniciada") => void;
+  showEditDeleteButtons?: boolean; // Nueva prop opcional
 }
 
-export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusChange }: RoundsCardProps) {
+export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusChange, showEditDeleteButtons = true }: RoundsCardProps) {
   const getClassNames = () => {
     switch (status) {
       case "activa":
@@ -62,7 +63,7 @@ export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusCh
   };
 
   return (
-    <Card key={id} className={`flex flex-row w-full p-4 gap-2 items-center ${getClassNames()}`}>
+    <Card key={id} className={`flex flex-col sm:flex-row w-full p-4 gap-2 items-center ${getClassNames()}`}>
       <div className="flex-1">
         <h1 className="text-2xl">{name}</h1>
       </div>
@@ -85,7 +86,7 @@ export default function RoundsCard({ id, name, status, pointTypesIDs, onStatusCh
             </Button>
           </>
         )}
-        {status === "noiniciada" && (
+        {status === "noiniciada" && showEditDeleteButtons && (
           <>
             <Button isIconOnly aria-label="Eliminar" color="danger" variant="light" size="md" onPress={() => { /* Lógica para eliminar */ }}>
               <span className="material-symbols-outlined">delete</span>

--- a/src/components/visor/teams/RoundsModal.tsx
+++ b/src/components/visor/teams/RoundsModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Button, Divider } from "@nextui-org/react";
 import RoundsCard from "@/components/visor/teams/RoundsCard";
 import { useParams } from "next/navigation";
+import TPuntoModal from "./TPuntoModal";
 
 interface Round {
   id: string;
@@ -26,6 +27,7 @@ export default function RoundsModal() {
     noStarted: [],
     paused: []
   });
+  const [selectedRound, setSelectedRound] = useState<Round | null>(null);
 
   const toggleExpand = () => {
     setIsExpanded(prev => !prev);
@@ -69,8 +71,23 @@ export default function RoundsModal() {
     getRounds();
   };
 
+  const handleRoundClick = (round: Round) => {
+    setSelectedRound(round);
+  };
+
+  const handleBackToRounds = () => {
+    setSelectedRound(null);
+  };
+
+  const handlePauseRounds = () => {
+    if (selectedRound) {
+      console.log(`Pausing round: ${selectedRound.id}`);
+      // Agrega aquí la lógica para pausar la ronda seleccionada
+    }
+  };
+
   return (
-    <div className="relative mx-auto w-full max-w-[740px] transition-all duration-500">
+    <div className="relative mx-auto w-full max-w-[740px] transition-all duration-500 ease-in-out">
       <div className="absolute left-1/2 top-0 transform -translate-x-1/2 -translate-y-1/2">
         <Button
           isIconOnly
@@ -84,64 +101,75 @@ export default function RoundsModal() {
           </span>
         </Button>
       </div>
-      <div className={`transition-all duration-500 overflow-hidden ${isExpanded ? "h-[600px] pt-8 overflow-y-auto" : "h-0"}`}>
+      <div className={`transition-all duration-500 ease-in-out overflow-hidden ${isExpanded ? "max-h-[600px] pt-8 overflow-y-auto" : "h-0"}`}>
         {isExpanded && (
           <div className="p-4">
-            {rounds.active.length > 0 && (
-              <div className="flex flex-col gap-4 w-full">
-                <h1 className="text-3xl">Rondas Activas</h1>
-                <div>
-                  {rounds.active.map(activeRound => (
-                    <RoundsCard
-                      key={activeRound.id}
-                      id={activeRound.id}
-                      name={activeRound.name}
-                      status={activeRound.status}
-                      pointTypesIDs={activeRound.pointTypesIDs}
-                      onStatusChange={handleStatusChange}
-                    />
-                  ))}
-                </div>
-                <Divider />
-              </div>
-            )}
-            {rounds.paused.length > 0 && (
-              <div className="flex flex-col gap-4 w-full">
-                <h1 className="text-3xl">Rondas Pausadas</h1>
-                <div>
-                  {rounds.paused.map(pausedRound => (
-                    <RoundsCard
-                      key={pausedRound.id}
-                      id={pausedRound.id}
-                      name={pausedRound.name}
-                      status={pausedRound.status}
-                      pointTypesIDs={pausedRound.pointTypesIDs}
-                      onStatusChange={handleStatusChange}
-                    />
-                  ))}
-                </div>
-                <Divider />
-              </div>
-            )}
-            {rounds.noStarted.length > 0 && (
-              <div className="flex flex-col gap-4 w-full">
-                <div className="flex flex-row justify-between">
-                  <h1 className="text-3xl">Futuras Rondas</h1>
-                </div>
-                <div className="flex flex-col gap-4">
-                  {rounds.noStarted.map(round => (
-                    <RoundsCard
-                      key={round.id}
-                      id={round.id}
-                      name={round.name}
-                      status={round.status}
-                      pointTypesIDs={round.pointTypesIDs}
-                      onStatusChange={handleStatusChange}
-                      showEditDeleteButtons={false} // Se pasa la prop para ocultar botones de editar y eliminar
-                    />
-                  ))}
-                </div>
-              </div>
+            {selectedRound ? (
+              <TPuntoModal
+                pointTypes={selectedRound.pointTypesIDs}
+                onBackToRounds={handleBackToRounds}
+                selectedRoundId={selectedRound.id}
+                onStatusChange={handleStatusChange}
+              />
+            ) : (
+              <>
+                {rounds.active.length > 0 && (
+                  <div className="flex flex-col gap-4 w-full">
+                    <h1 className="text-3xl">Rondas Activas</h1>
+                    <div>
+                      {rounds.active.map(activeRound => (
+                        <RoundsCard
+                          key={activeRound.id}
+                          id={activeRound.id}
+                          name={activeRound.name}
+                          status={activeRound.status}
+                          pointTypesIDs={activeRound.pointTypesIDs}
+                          onStatusChange={handleStatusChange}
+                          onCardClick={() => handleRoundClick(activeRound)}
+                        />
+                      ))}
+                    </div>
+                    <Divider />
+                  </div>
+                )}
+                {rounds.paused.length > 0 && (
+                  <div className="flex flex-col gap-4 w-full">
+                    <h1 className="text-3xl">Rondas Pausadas</h1>
+                    <div>
+                      {rounds.paused.map(pausedRound => (
+                        <RoundsCard
+                          key={pausedRound.id}
+                          id={pausedRound.id}
+                          name={pausedRound.name}
+                          status={pausedRound.status}
+                          pointTypesIDs={pausedRound.pointTypesIDs}
+                          onStatusChange={handleStatusChange}
+                          onCardClick={() => { }} // No hacemos nada al clicar en rondas pausadas
+                        />
+                      ))}
+                    </div>
+                    <Divider />
+                  </div>
+                )}
+                {rounds.noStarted.length > 0 && (
+                  <div className="flex flex-col gap-4 w-full">
+                    <h1 className="text-3xl">Rondas Futuras</h1>
+                    <div className="flex flex-col gap-4">
+                      {rounds.noStarted.map(noStartedRound => (
+                        <RoundsCard
+                          key={noStartedRound.id}
+                          id={noStartedRound.id}
+                          name={noStartedRound.name}
+                          status={noStartedRound.status}
+                          pointTypesIDs={noStartedRound.pointTypesIDs}
+                          onStatusChange={handleStatusChange}
+                          onCardClick={() => { }} // No hacemos nada al clicar en rondas no iniciadas
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
             )}
           </div>
         )}

--- a/src/components/visor/teams/RoundsModal.tsx
+++ b/src/components/visor/teams/RoundsModal.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button, Divider } from "@nextui-org/react";
+import RoundsCard from "@/components/visor/teams/RoundsCard";
+import { useParams } from "next/navigation";
+
+interface Round {
+  id: string;
+  name: string;
+  status: "activa" | "pausada" | "noiniciada";
+  pointTypesIDs: string[];
+}
+
+interface Rounds {
+  active: Round[];
+  paused: Round[];
+  noStarted: Round[];
+}
+
+export default function RoundsModal() {
+  const { id: teamId } = useParams();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [rounds, setRounds] = useState<Rounds>({
+    active: [],
+    noStarted: [],
+    paused: []
+  });
+
+  const toggleExpand = () => {
+    setIsExpanded(prev => !prev);
+  };
+
+  const getRounds = async () => {
+    try {
+      console.log(`Fetching rounds for teamId: ${teamId}`);
+      const response = await fetch(`/dashboard/api/visor/teams/${teamId}/rounds`);
+      const data = await response.json();
+
+      if (data.code === "OK" && data.data) {
+        console.log("Fetched rounds:", data.data);
+        const activeRounds = data.data.active;
+        const pausedRounds = data.data.paused;
+        const noStartedRounds = data.data.noStarted;
+        console.log("Active rounds:", activeRounds);
+        console.log("Paused rounds:", pausedRounds);
+        console.log("No started rounds:", noStartedRounds);
+        setRounds({
+          active: activeRounds,
+          paused: pausedRounds,
+          noStarted: noStartedRounds
+        });
+      } else {
+        console.error(data.message);
+      }
+    } catch (error) {
+      console.error("Error fetching rounds:", error);
+    }
+  };
+
+  useEffect(() => {
+    console.log(`Component mounted, teamId: ${teamId}`);
+    if (teamId) {
+      getRounds();
+    }
+  }, [teamId]);
+
+  const handleStatusChange = () => {
+    getRounds();
+  };
+
+  return (
+    <div className="relative mx-auto w-full max-w-[740px] transition-all duration-500">
+      <div className="absolute left-1/2 top-0 transform -translate-x-1/2 -translate-y-1/2">
+        <Button
+          isIconOnly
+          color="default"
+          variant="light"
+          size="md"
+          onPress={toggleExpand}
+        >
+          <span className="material-symbols-outlined">
+            {isExpanded ? "arrow_circle_up" : "arrow_circle_down"}
+          </span>
+        </Button>
+      </div>
+      <div className={`transition-all duration-500 overflow-hidden ${isExpanded ? "h-[600px] pt-8 overflow-y-auto" : "h-0"}`}>
+        {isExpanded && (
+          <div className="p-4">
+            {rounds.paused.length > 0 && (
+              <div className="flex flex-col gap-4 w-full">
+                <h1 className="text-3xl">Rondas Pausadas</h1>
+                <div>
+                  {rounds.paused.map(pausedRound => (
+                    <RoundsCard
+                      key={pausedRound.id}
+                      id={pausedRound.id}
+                      name={pausedRound.name}
+                      status={pausedRound.status}
+                      pointTypesIDs={pausedRound.pointTypesIDs}
+                      onStatusChange={handleStatusChange}
+                    />
+                  ))}
+                </div>
+                <Divider />
+              </div>
+            )}
+            {rounds.noStarted.length > 0 && (
+              <div className="flex flex-col gap-4 w-full">
+                <div className="flex flex-row justify-between">
+                  <h1 className="text-3xl">Futuras Rondas</h1>
+                </div>
+                <div className="flex flex-col gap-4">
+                  {rounds.noStarted.map(round => (
+                    <RoundsCard
+                      key={round.id}
+                      id={round.id}
+                      name={round.name}
+                      status={round.status}
+                      pointTypesIDs={round.pointTypesIDs}
+                      onStatusChange={handleStatusChange}
+                      showEditDeleteButtons={false}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/visor/teams/RoundsModal.tsx
+++ b/src/components/visor/teams/RoundsModal.tsx
@@ -87,6 +87,24 @@ export default function RoundsModal() {
       <div className={`transition-all duration-500 overflow-hidden ${isExpanded ? "h-[600px] pt-8 overflow-y-auto" : "h-0"}`}>
         {isExpanded && (
           <div className="p-4">
+            {rounds.active.length > 0 && (
+              <div className="flex flex-col gap-4 w-full">
+                <h1 className="text-3xl">Rondas Activas</h1>
+                <div>
+                  {rounds.active.map(activeRound => (
+                    <RoundsCard
+                      key={activeRound.id}
+                      id={activeRound.id}
+                      name={activeRound.name}
+                      status={activeRound.status}
+                      pointTypesIDs={activeRound.pointTypesIDs}
+                      onStatusChange={handleStatusChange}
+                    />
+                  ))}
+                </div>
+                <Divider />
+              </div>
+            )}
             {rounds.paused.length > 0 && (
               <div className="flex flex-col gap-4 w-full">
                 <h1 className="text-3xl">Rondas Pausadas</h1>
@@ -119,7 +137,7 @@ export default function RoundsModal() {
                       status={round.status}
                       pointTypesIDs={round.pointTypesIDs}
                       onStatusChange={handleStatusChange}
-                      showEditDeleteButtons={false}
+                      showEditDeleteButtons={false} // Se pasa la prop para ocultar botones de editar y eliminar
                     />
                   ))}
                 </div>

--- a/src/components/visor/teams/TPuntoModal.tsx
+++ b/src/components/visor/teams/TPuntoModal.tsx
@@ -1,0 +1,68 @@
+import { Card, Button } from "@nextui-org/react";
+
+interface TPuntoModalProps {
+  pointTypes: string[];
+  onBackToRounds: () => void;
+  selectedRoundId: string; // ID de la ronda seleccionada
+  onStatusChange: (id: string, newStatus: "activa" | "pausada" | "noiniciada") => void;
+}
+
+export default function TPuntoModal({ pointTypes, onBackToRounds, selectedRoundId, onStatusChange }: TPuntoModalProps) {
+
+  const updateStatus = async (action: "start" | "pause" | "stop") => {
+    try {
+      const response = await fetch(`/dashboard/api/visor/rounds/${selectedRoundId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action }),
+      });
+      const data = await response.json();
+      if (data.code === "OK") {
+        const newStatus = action === "start" ? "activa" : action === "pause" ? "pausada" : "noiniciada";
+        onStatusChange(selectedRoundId, newStatus);
+      } else {
+        console.error(data.message);
+      }
+    } catch (error) {
+      console.error("Error updating status:", error);
+    }
+  };
+
+  const handlePause = () => {
+    updateStatus("pause");
+  };
+
+  const capitalizeFirstLetter = (string: string) => {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 w-full max-w-[740px] max-h-[600px]">
+      <h1 className="text-md text-center">Selecciona el tipo de punto</h1>
+      <div className="flex flex-wrap gap-4 justify-center">
+        {pointTypes.map((type, index) => (
+          <Card
+            key={index}
+            isPressable
+            className="flex flex-col w-[80px] h-[80px] p-4 gap-2 items-center text-primary-foreground"
+            radius="sm"
+          >
+            <div className="flex-1 text-left content-center">
+              <h1 className="text-xs truncate text-foreground-700">{capitalizeFirstLetter(type)}</h1>
+            </div>
+          </Card>
+        ))}
+      </div>
+      <div className="flex flex-row gap-4 justify-between">
+        <Button isIconOnly color="default" variant="light" size="md" onPress={onBackToRounds}>
+          <span className="material-symbols-outlined">arrow_back</span>
+        </Button>
+        <Button color="danger" onPress={handlePause}>
+          Pausar ronda
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Añadi el menu y la conexion para que en el modal donde ves las rondas, al hacer click en la ronda activa te lleve al menu de tipos de punto

- Solo se le puede hacer click a la card con ronda activa:

![image](https://github.com/user-attachments/assets/021a8e67-d7f9-40e4-91b1-dd3e87069a29)

- El boton de pausar ronda, pausa la ronda actual:

![image](https://github.com/user-attachments/assets/7d2a8db4-d900-46f2-a3da-0f39fa1970f1)

- Añadi un boton para regresar al menu de rondas

- Asi se ve el menu:

![image](https://github.com/user-attachments/assets/39649d38-7305-46b3-8f70-f1c139f23176)

(No puse el icono, porque no se que icono va a tener cada tipo de punto. Busco algunos a mi consideracion?)


